### PR TITLE
refac:updated design to match new figma

### DIFF
--- a/src/app/dashboard/institution/page.tsx
+++ b/src/app/dashboard/institution/page.tsx
@@ -133,8 +133,8 @@ export default function InstitutionDashboardPage() {
                 {/* Created Exams Section */}
                 <div>
                   <h2 className="text-xl mb-4 text-gray-300">Created Exams</h2>
-                  <div className="bg-[#0f1c3f] rounded-lg p-6">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                  <div className="bg-[#0f1c3f] rounded-lg p-1">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                       {exams.map((exam) => (
                         <ExamCard
                           key={exam.id}
@@ -143,20 +143,14 @@ export default function InstitutionDashboardPage() {
                         />
                       ))}
                     </div>
-                    <Link
-                      href="/exams"
-                      className="block w-full text-center py-3 bg-[#0a1128] hover:bg-black rounded-lg transition-colors"
-                    >
-                      Go To Page
-                    </Link>
                   </div>
                 </div>
 
                 {/* Drafts Section */}
                 <div>
                   <h2 className="text-xl mb-4 text-gray-300">Drafts</h2>
-                  <div className="bg-[#0f1c3f] rounded-lg p-6">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                  <div className="bg-[#0f1c3f] rounded-lg p-1">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                       {exams.map((exam) => (
                         <ExamCard
                           key={`draft-${exam.id}`}
@@ -165,12 +159,6 @@ export default function InstitutionDashboardPage() {
                         />
                       ))}
                     </div>
-                    <Link
-                      href="/exams"
-                      className="block w-full text-center py-3 bg-[#0a1128] hover:bg-black rounded-lg transition-colors"
-                    >
-                      Go To Page
-                    </Link>
                   </div>
                 </div>
               </div>

--- a/src/components/dashboard/exam/components/new-dashboard-layout.tsx
+++ b/src/components/dashboard/exam/components/new-dashboard-layout.tsx
@@ -28,7 +28,7 @@ import { redirect } from "next/navigation";
 interface DashboardLayoutProps {
   children: ReactNode;
   title: string;
-  activePage: "dashboard" | "my-exams" | "certificates" | "register" | "help";
+  activePage: "dashboard" | "my-exams" | "certificates" | "help";
 }
 
 export default function DashboardLayout({
@@ -139,13 +139,7 @@ export default function DashboardLayout({
       label: "View Certificates",
       icon: CertificateIcon,
       href: "/dashboard/user/view-certificate",
-    },
-    {
-      key: "register",
-      label: "Register For Exams",
-      icon: RegisterIcon,
-      href: "/dashboard/user/register-exam",
-    },
+    }
   ];
 
   // --- Animation Variants ---

--- a/src/components/dashboard/exam/components/ui/my-exam-card.tsx
+++ b/src/components/dashboard/exam/components/ui/my-exam-card.tsx
@@ -3,8 +3,8 @@ import { buffer } from "stream/consumers";
 
 // Function to handle click for taking exam
 
-const handleCLickTakeExam = () => {
-  window.location.href = "/dashboard/exam-page";
+const handleCLickRegisterExam = () => {
+  window.location.href = "/dashboard/user/register-exam";
 };
 const MyExamCard = ({
   title,
@@ -34,10 +34,10 @@ const MyExamCard = ({
       </button>
     ) : (
       <button
-        onClick={handleCLickTakeExam}
+        onClick={handleCLickRegisterExam}
         className="text-white border border-[#F4F9FF] rounded-full py-2 px-4 w-full hover:bg-gray-700 transition-colors"
       >
-        Take Exam
+        Register for Exam
       </button>
     )}
   </div>

--- a/src/components/dashboard/institution/components/exam-card.tsx
+++ b/src/components/dashboard/institution/components/exam-card.tsx
@@ -19,6 +19,10 @@ interface ExamCardProps {
   onTakeExam: () => void;
 }
 
+const handleCLickViewExamDetails = () => {
+  window.location.href = "/dashboard/institution/created-exam";
+};
+
 export default function ExamCard({ exam, onTakeExam }: ExamCardProps) {
   return (
     <div className="bg-[#0a1128] rounded-lg p-6 flex flex-col text-center items-center">
@@ -36,10 +40,10 @@ export default function ExamCard({ exam, onTakeExam }: ExamCardProps) {
       <h3 className="text-lg font-semibold mb-2">{exam.title}</h3>
       <p className="text-sm text-gray-300 mb-6">{exam.description}</p>
       <Button
-        onClick={onTakeExam}
-        className="w-full py-2 border border-teal-500 text-teal-500 hover:bg-teal-500 hover:text-white rounded-lg transition-colors bg-transparent"
+        onClick={handleCLickViewExamDetails}
+        className="w-full py-1 text-sm border border-teal-500 text-teal-500 hover:bg-teal-500 hover:text-white rounded-lg transition-colors bg-transparent"
       >
-        Take Exam
+        View Exam Details
       </Button>
     </div>
   );

--- a/src/components/dashboard/institution/components/modals/exam-details-modal.tsx
+++ b/src/components/dashboard/institution/components/modals/exam-details-modal.tsx
@@ -85,7 +85,7 @@ export default function ExamDetailsModal({ exam, onClose }: ExamDetailsModalProp
                   variant="outline"
                   className="bg-transparent border border-gray-600 hover:bg-gray-700 rounded-full px-4 py-2 text-sm"
                 >
-                  Go to Page
+                  Close
                 </Button>
               </Link>
             </div>


### PR DESCRIPTION
Resolve #77 
1: Changed the button text from take exam to register for exam on the user dashboard
2: Connected the register button to the register modal on the user dashboard
3: On the my exams on the user dashboard, Once the user clicks on take exam, The verify modal should be displayed, Once the user fills it , redirect the user to exam details page then finally the exam-page.
4: Removed register exam from the side navbar of the user dashboard
5: On the institution dashboard, changed the take exam button to view exam details and connect it to the created exam page on the side navbar
6: Took out the go to page button
7: Changed the go to page to close on the view details modal on the institution dashboard

